### PR TITLE
Scaffold admin, template and app packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# BP Self Registration Monorepo
+
+This repository contains multiple packages managed with npm workspaces.
+
+## Getting Started
+
+Install dependencies for all workspaces:
+
+```bash
+npm install
+```
+
+### Development
+
+Run the admin panel:
+
+```bash
+npm run dev:admin
+```
+
+Run the self‑registration app:
+
+```bash
+npm run dev:app
+```
+
+### Scaffold a New App
+
+```bash
+cd self-reg-app-template && npx hygen self-reg-app new
+```

--- a/admin-panel/app/globals.css
+++ b/admin-panel/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/admin-panel/app/layout.tsx
+++ b/admin-panel/app/layout.tsx
@@ -1,0 +1,10 @@
+import './globals.css'
+import { ReactNode } from 'react'
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-gray-50">{children}</body>
+    </html>
+  )
+}

--- a/admin-panel/app/page.tsx
+++ b/admin-panel/app/page.tsx
@@ -1,0 +1,7 @@
+export default function Home() {
+  return (
+    <main className="p-8">
+      <h1 className="text-2xl font-bold">Admin Panel</h1>
+    </main>
+  )
+}

--- a/admin-panel/app/settings/page.tsx
+++ b/admin-panel/app/settings/page.tsx
@@ -1,0 +1,46 @@
+'use client'
+import { useState } from 'react'
+
+const categories = [
+  { id: 'metered', label: 'Metered' },
+  { id: 'recurring', label: 'Recurring' },
+  { id: 'oneTime', label: 'One-Time Charge' },
+]
+
+export default function Settings() {
+  const [enabled, setEnabled] = useState<string[]>([])
+
+  const toggle = (id: string) => {
+    setEnabled((prev) =>
+      prev.includes(id) ? prev.filter((p) => p !== id) : [...prev, id]
+    )
+  }
+
+  const save = () => {
+    // TODO: save config to API
+    console.log('Save config', enabled)
+  }
+
+  return (
+    <main className="p-8">
+      <h1 className="text-xl font-bold mb-4">Settings</h1>
+      <ul className="space-y-2">
+        {categories.map((c) => (
+          <li key={c.id}>
+            <label className="flex items-center space-x-2">
+              <input
+                type="checkbox"
+                checked={enabled.includes(c.id)}
+                onChange={() => toggle(c.id)}
+              />
+              <span>{c.label}</span>
+            </label>
+          </li>
+        ))}
+      </ul>
+      <button className="mt-4 px-4 py-2 bg-blue-600 text-white" onClick={save}>
+        Save
+      </button>
+    </main>
+  )
+}

--- a/admin-panel/lib/scaffolder.ts
+++ b/admin-panel/lib/scaffolder.ts
@@ -1,0 +1,7 @@
+// Stubbed scaffolder client
+// TODO: use Octokit or fetch to clone template repo,
+// replace placeholders, and push to the target repo.
+export async function generateRepository(config: object) {
+  console.log('Scaffolding with config', config)
+  // API calls go here
+}

--- a/admin-panel/package.json
+++ b/admin-panel/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "admin-panel",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "13.4.13",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.21",
+    "tailwindcss": "^3.3.2",
+    "typescript": "^5.1.6"
+  }
+}

--- a/admin-panel/postcss.config.js
+++ b/admin-panel/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/admin-panel/tailwind.config.js
+++ b/admin-panel/tailwind.config.js
@@ -1,0 +1,12 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './app/**/*.{ts,tsx}',
+    './pages/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/admin-panel/tsconfig.json
+++ b/admin-panel/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/tsconfig.json"
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "bp-self-registration",
+  "private": true,
+  "workspaces": [
+    "admin-panel",
+    "self-reg-app-template",
+    "self-reg-app"
+  ],
+  "scripts": {
+    "dev:admin": "npm run dev --workspace=admin-panel",
+    "dev:app": "npm run dev --workspace=self-reg-app",
+    "scaffold": "npm --workspace=self-reg-app-template exec hygen self-reg-app new"
+  }
+}

--- a/self-reg-app-template/_templates/self-reg-app/new/.env.example.ejs
+++ b/self-reg-app-template/_templates/self-reg-app/new/.env.example.ejs
@@ -1,0 +1,2 @@
+# Example environment variables
+API_BASE=<%= h.prompt('api_base') %>

--- a/self-reg-app-template/_templates/self-reg-app/new/app/page.tsx.ejs
+++ b/self-reg-app-template/_templates/self-reg-app/new/app/page.tsx.ejs
@@ -1,0 +1,7 @@
+export default function Page() {
+  return (
+    <main className="p-8">
+      {/* TODO: render product forms */}
+    </main>
+  )
+}

--- a/self-reg-app-template/_templates/self-reg-app/new/components/ProductForm.tsx.ejs
+++ b/self-reg-app-template/_templates/self-reg-app/new/components/ProductForm.tsx.ejs
@@ -1,0 +1,5 @@
+export default function ProductForm() {
+  return (
+    <form>{/* TODO: product form fields */}</form>
+  )
+}

--- a/self-reg-app-template/_templates/self-reg-app/new/config/default.json.ejs
+++ b/self-reg-app-template/_templates/self-reg-app/new/config/default.json.ejs
@@ -1,0 +1,7 @@
+{
+  "apiBase": "<%= h.prompt('api_base') %>",
+  "productTypes": <%= h.prompt('product_types') %>,
+  "branding": {
+    "clientName": "<%= h.prompt('client_name') %>"
+  }
+}

--- a/self-reg-app-template/_templates/self-reg-app/new/hooks/useConfig.ts.ejs
+++ b/self-reg-app-template/_templates/self-reg-app/new/hooks/useConfig.ts.ejs
@@ -1,0 +1,3 @@
+export function useConfig() {
+  // TODO: load config from public directory
+}

--- a/self-reg-app-template/_templates/self-reg-app/new/package.json.ejs
+++ b/self-reg-app-template/_templates/self-reg-app/new/package.json.ejs
@@ -1,0 +1,4 @@
+{
+  "name": "<%= h.inflection.dasherize(name) %>",
+  "private": true
+}

--- a/self-reg-app-template/_templates/self-reg-app/new/services/api.ts.ejs
+++ b/self-reg-app-template/_templates/self-reg-app/new/services/api.ts.ejs
@@ -1,0 +1,3 @@
+export async function apiRequest() {
+  // TODO: implement API request logic
+}

--- a/self-reg-app-template/_templates/self-reg-app/new/styles/globals.css.ejs
+++ b/self-reg-app-template/_templates/self-reg-app/new/styles/globals.css.ejs
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/self-reg-app-template/_templates/self-reg-app/new/tailwind.config.js.ejs
+++ b/self-reg-app-template/_templates/self-reg-app/new/tailwind.config.js.ejs
@@ -1,0 +1,6 @@
+/** Tailwind config */
+module.exports = {
+  content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'],
+  theme: { extend: {} },
+  plugins: [],
+}

--- a/self-reg-app-template/_templates/self-reg-app/new/types/config.d.ts.ejs
+++ b/self-reg-app-template/_templates/self-reg-app/new/types/config.d.ts.ejs
@@ -1,0 +1,5 @@
+export interface Config {
+  apiBase: string
+  productTypes: any
+  branding: { clientName: string }
+}

--- a/self-reg-app-template/package.json
+++ b/self-reg-app-template/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "self-reg-app-template",
+  "private": true,
+  "version": "0.0.0",
+  "devDependencies": {
+    "hygen": "^6.2.9",
+    "typescript": "^5.1.6"
+  }
+}

--- a/self-reg-app-template/tsconfig.json
+++ b/self-reg-app-template/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "strict": true
+  }
+}

--- a/self-reg-app/app/layout.tsx
+++ b/self-reg-app/app/layout.tsx
@@ -1,0 +1,16 @@
+"use client"
+import '../styles/globals.css'
+import { ReactNode } from 'react'
+import { useConfig } from '../hooks/useConfig'
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  const config = useConfig()
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-white text-gray-800">
+        {/* TODO: apply theme from config */}
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/self-reg-app/app/page.tsx
+++ b/self-reg-app/app/page.tsx
@@ -1,0 +1,21 @@
+"use client"
+import ProductForm from '../components/ProductForm'
+import { useConfig } from '../hooks/useConfig'
+
+export default function Page() {
+  const config = useConfig()
+
+  if (!config) return <p>Loading...</p>
+
+  return (
+    <main className="p-8 space-y-4">
+      {config.productTypes.map((p) => (
+        <div key={p.id} className="border p-4 rounded">
+          <h2 className="font-bold mb-2">{p.name}</h2>
+          <p className="mb-2">{p.description}</p>
+          <ProductForm />
+        </div>
+      ))}
+    </main>
+  )
+}

--- a/self-reg-app/components/ProductForm.tsx
+++ b/self-reg-app/components/ProductForm.tsx
@@ -1,0 +1,5 @@
+export default function ProductForm() {
+  return (
+    <form>{/* TODO: implement product form */}</form>
+  )
+}

--- a/self-reg-app/hooks/useConfig.ts
+++ b/self-reg-app/hooks/useConfig.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react'
+
+export interface Config {
+  branding: { clientName: string }
+  apiBase: string
+  productTypes: any[]
+}
+
+export function useConfig() {
+  const [config, setConfig] = useState<Config | null>(null)
+
+  useEffect(() => {
+    fetch('/config/default.json')
+      .then((res) => res.json())
+      .then(setConfig)
+  }, [])
+
+  return config
+}

--- a/self-reg-app/package.json
+++ b/self-reg-app/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "self-reg-app",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "13.4.13",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.21",
+    "tailwindcss": "^3.3.2",
+    "typescript": "^5.1.6"
+  }
+}

--- a/self-reg-app/postcss.config.js
+++ b/self-reg-app/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/self-reg-app/public/config/default.json
+++ b/self-reg-app/public/config/default.json
@@ -1,0 +1,18 @@
+{
+  "branding": {
+    "clientName": "Example Corp"
+  },
+  "apiBase": "https://api.example.com",
+  "productTypes": [
+    {
+      "id": "metered",
+      "name": "Metered",
+      "description": "Usage based product"
+    },
+    {
+      "id": "recurring",
+      "name": "Recurring",
+      "description": "Subscription product"
+    }
+  ]
+}

--- a/self-reg-app/styles/globals.css
+++ b/self-reg-app/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/self-reg-app/tailwind.config.js
+++ b/self-reg-app/tailwind.config.js
@@ -1,0 +1,6 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'],
+  theme: { extend: {} },
+  plugins: [],
+}

--- a/self-reg-app/tsconfig.json
+++ b/self-reg-app/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/tsconfig.json"
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./admin-panel" },
+    { "path": "./self-reg-app-template" },
+    { "path": "./self-reg-app" }
+  ]
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js admin panel with settings page and scaffolder stub
- add Hygen template for self-reg app
- scaffold self registration app with dynamic config loader
- setup workspaces, TypeScript references, and README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6888b9035c208327a4cdebdbb19fd965